### PR TITLE
fix(minato): fix relation issues

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -1,4 +1,4 @@
-import { deduplicate, defineProperty, Dict, filterKeys, makeArray, mapValues, MaybeArray, noop, omit, pick } from 'cosmokit'
+import { deduplicate, defineProperty, Dict, filterKeys, isNullable, makeArray, mapValues, MaybeArray, noop, omit, pick, remove } from 'cosmokit'
 import { Context, Service, Spread } from 'cordis'
 import { AtomicTypes, DeepPartial, FlatKeys, FlatPick, Flatten, getCell, Indexable, Keys, randomId, Row, unravel, Values } from './utils.ts'
 import { Selection } from './selection.ts'
@@ -50,12 +50,14 @@ export type Create<T, S> =
   | T extends Values<AtomicTypes> ? T
   : T extends (infer I extends Values<S>)[] ? CreateMap<I, S>[] |
     {
+      $literal?: DeepPartial<I>
       $create?: MaybeArray<CreateMap<I, S>>
       $upsert?: MaybeArray<CreateMap<I, S>>
       $connect?: Query.Expr<Flatten<I>>
     }
   : T extends Values<S> ? CreateMap<T, S> |
     {
+      $literal?: DeepPartial<T>
       $create?: CreateMap<T, S>
       $upsert?: CreateMap<T, S>
       $connect?: Query.Expr<Flatten<T>>
@@ -356,7 +358,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
           ), true)
           sel = applyQuery(sel, key)
           sel = whereOnly ? sel : sel.groupBy([
-            ...Object.entries(modelFields).filter(([, field]) => Field.available(field)).map(([k]) => k),
+            ...Object.entries(modelFields).filter(([k, field]) => !extraFields.some(x => k.startsWith(`${x}.`)) && Field.available(field)).map(([k]) => k),
             ...extraFields,
           ], {
             [key]: row => Eval.ignoreNull(Eval.array(row[key])),
@@ -374,7 +376,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
           ), true)
           sel = applyQuery(sel, key)
           sel = whereOnly ? sel : sel.groupBy([
-            ...Object.entries(modelFields).filter(([, field]) => Field.available(field)).map(([k]) => k),
+            ...Object.entries(modelFields).filter(([k, field]) => !extraFields.some(x => k.startsWith(`${x}.`)) && Field.available(field)).map(([k]) => k),
             ...extraFields,
           ], {
             [key]: row => Eval.ignoreNull(Eval.array(row[key][relation.table as any])),
@@ -429,7 +431,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
   async get<K extends Keys<S>, P extends FlatKeys<S[K]> = any>(
     table: K,
     query: Query<S[K]>,
-    cursor?: Driver.Cursor<S[K], Values<S>, P>,
+    cursor?: Driver.Cursor<P, S[K], Values<S>>,
   ): Promise<FlatPick<S[K], P>[]>
 
   async get<K extends Keys<S>>(table: K, query: Query<S[K]>, cursor?: any) {
@@ -484,18 +486,8 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
   async create<K extends Keys<S>>(table: K, data: Create<S[K], S>): Promise<S[K]>
   async create<K extends Keys<S>>(table: K, data: any): Promise<S[K]> {
     const sel = this.select(table)
-    let hasRelation = false
-    for (const key in data) {
-      if (data[key] !== undefined && this.tables[table].fields[key]?.relation) {
-        const relation = this.tables[table].fields[key].relation
-        if (relation.type === 'oneToOne' && !relation.required && !isUpdateExpr(data[key])) continue
-        if (relation.type === 'manyToOne' && !isUpdateExpr(data[key])) continue
-        hasRelation = true
-        break
-      }
-    }
 
-    if (!hasRelation) {
+    if (!this.hasRelation(table, data)) {
       const { primary, autoInc } = sel.model
       if (!autoInc) {
         const keys = makeArray(primary)
@@ -679,20 +671,22 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         if (relation.type === 'oneToOne' && relation.required) tasks.push(key)
         else if (relation.type === 'oneToOne' && isUpdateExpr(data[key])) tasks.unshift(key)
         else if (relation.type === 'oneToMany') tasks.push(key)
-        else if (relation.type === 'manyToOne' && isUpdateExpr(data[key])) tasks.unshift(key)
+        else if (relation.type === 'manyToOne') tasks.unshift(key)
         else if (relation.type === 'manyToMany') tasks.push(key)
       }
     }
 
-    for (const key of tasks) {
+    for (const key of [...tasks]) {
       if (!key) {
         // create the plain data, with or without upsert
         const { primary, autoInc } = sel.model
         const keys = makeArray(primary)
-        if (keys.some(key => getCell(data, key) === undefined)) {
+        if (keys.some(key => isNullable(getCell(data, key)))) {
           if (!autoInc) {
             throw new Error('missing primary key')
           } else {
+            // nullable relation may pass null here, remove it to enable autoInc
+            delete data[primary as string]
             upsert = false
           }
         }
@@ -703,10 +697,13 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         }
         continue
       }
-      const value: Relation.Modifier = data[key]
+      const value = data[key]
       const relation: Relation.Config<S> = this.tables[table].fields[key]!.relation! as any
       if (relation.type === 'oneToOne') {
-        if (value.$create || value.$upsert || !isUpdateExpr(value)) {
+        if (value.$literal) {
+          data[key] = value.$literal
+          remove(tasks, key)
+        } else if (value.$create || value.$upsert || !isUpdateExpr(value)) {
           const result = await this.createOrUpdate(relation.table, {
             ...Object.fromEntries(relation.references.map((k, i) => [k, getCell(data, relation.fields[i])])),
             ...value.$create ?? value.$upsert ?? value,
@@ -728,7 +725,10 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
           }
         }
       } else if (relation.type === 'manyToOne') {
-        if (value.$create || !isUpdateExpr(value)) {
+        if (value.$literal) {
+          data[key] = value.$literal
+          remove(tasks, key)
+        } else if (value.$create || !isUpdateExpr(value)) {
           const result = await this.createOrUpdate(relation.table, value.$create ?? value)
           relation.references.forEach((k, i) => data[relation.fields[i]] = getCell(result, k))
         } else if (value.$upsert) {
@@ -810,7 +810,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         value = relation.required ? { $remove: {} } : { $disconnect: {} }
       }
       if (typeof value === 'object' && !isUpdateExpr(value)) {
-        value = { $upsert: value }
+        value = { $create: value }
       }
       if (value.$remove) {
         await this.remove(relation.table, Object.fromEntries(relation.references.map((k, i) => [k, getCell(row, relation.fields[i])])) as any)
@@ -879,7 +879,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         value = { $disconnect: {} }
       }
       if (typeof value === 'object' && !isUpdateExpr(value)) {
-        value = { $upsert: value } as any
+        value = { $create: value }
       }
       if (value.$remove) {
         await this.remove(relation.table, Object.fromEntries(relation.references.map((k, i) => [k, getCell(row, relation.fields[i])])) as any)
@@ -899,7 +899,10 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         )
       }
       if (value.$create) {
-        const result = await this.createOrUpdate(relation.table, value.$create)
+        const result = await this.createOrUpdate(relation.table, {
+          ...Object.fromEntries(relation.references.map((k, i) => [k, getCell(row, relation.fields[i])])),
+          ...value.$create,
+        })
         await this.set(
           table,
           pick(model.format(row), makeArray(model.primary)),
@@ -923,8 +926,9 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
       }
     } else if (relation.type === 'oneToMany') {
       if (Array.isArray(value)) {
-        // default to upsert, this will block nested relation update
-        value = { $remove: {}, $upsert: value }
+        const $create: any[] = [], $upsert: any[] = []
+        value.forEach(item => this.hasRelation(relation.table, item) ? $create.push(item) : $upsert.push(item))
+        value = { $remove: {}, $create, $upsert }
       }
       if (value.$remove) {
         await this.remove(relation.table, (r: any) => Eval.query(r, {
@@ -982,8 +986,9 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         reference: y,
       }] as const)
       if (Array.isArray(value)) {
-        // default to upsert, this will block nested relation update
-        value = { $disconnect: {}, $upsert: value }
+        const $create: any[] = [], $upsert: any[] = []
+        value.forEach(item => this.hasRelation(relation.table, item) ? $create.push(item) : $upsert.push(item))
+        value = { $disconnect: {}, $create, $upsert }
       }
       if (value.$remove) {
         const rows = await this.select(assocTable, {
@@ -1065,5 +1070,17 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
         })) as any)
       }
     }
+  }
+
+  private hasRelation<K extends Keys<S>>(table: K, data: Create<S[K], S>): boolean
+  private hasRelation(table: any, data: any) {
+    for (const key in data) {
+      if (data[key] !== undefined && this.tables[table].fields[key]?.relation) {
+        const relation = this.tables[table].fields[key].relation
+        if (relation.type === 'oneToOne' && !relation.required && !isUpdateExpr(data[key])) continue
+        return true
+      }
+    }
+    return false
   }
 }

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -442,7 +442,7 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
   async get<K extends Keys<S>, P extends FlatKeys<S[K]> = any>(
     table: K,
     query: Query<S[K]>,
-    cursor?: Driver.Cursor<P, S[K], Values<S>>,
+    cursor?: Driver.Cursor<P, S, K>,
   ): Promise<FlatPick<S[K], P>[]>
 
   async get<K extends Keys<S>>(table: K, query: Query<S[K]>, cursor?: any) {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -5,7 +5,7 @@ import { Direction, Modifier, Selection } from './selection.ts'
 import { Field, Model, Relation } from './model.ts'
 import { Database } from './database.ts'
 import { Type } from './type.ts'
-import { FlatKeys } from './utils.ts'
+import { Keys, Values } from './utils.ts'
 
 export namespace Driver {
   export interface Stats {
@@ -18,14 +18,14 @@ export namespace Driver {
     size: number
   }
 
-  export type Cursor<K extends FlatKeys<T> = any, T = any, S = any> = K[] | CursorOptions<K, T, S>
+  export type Cursor<K extends string = string, S = any, T extends Keys<S> = any> = K[] | CursorOptions<K, S, T>
 
-  export interface CursorOptions<K extends FlatKeys<T> = any, T = any, S = any> {
+  export interface CursorOptions<K extends string = string, S = any, T extends Keys<S> = any> {
     limit?: number
     offset?: number
     fields?: K[]
     sort?: Dict<Direction, K>
-    include?: Relation.Include<T, S>
+    include?: Relation.Include<S[T], Values<S>>
   }
 
   export interface WriteResult {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -18,9 +18,9 @@ export namespace Driver {
     size: number
   }
 
-  export type Cursor<T = any, S = any, K extends FlatKeys<T> = any> = K[] | CursorOptions<T, S, K>
+  export type Cursor<K extends FlatKeys<T> = any, T = any, S = any> = K[] | CursorOptions<K, T, S>
 
-  export interface CursorOptions<T = any, S = any, K extends FlatKeys<T> = any> {
+  export interface CursorOptions<K extends FlatKeys<T> = any, T = any, S = any> {
     limit?: number
     offset?: number
     fields?: K[]

--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -77,7 +77,7 @@ export namespace Eval {
 
     ignoreNull<T, A extends boolean>(value: Eval.Expr<T, A>): Eval.Expr<T, A>
     select(...args: Any[]): Expr<any[], false>
-    query<T extends object>(row: Row<T>, query: Query.Expr<T>): Expr<boolean, false>
+    query<T extends object>(row: Row<T>, query: Query.Expr<T>, expr?: Term<boolean>): Expr<boolean, false>
 
     // univeral
     if<T extends Comparable, A extends boolean>(cond: Any<A>, vThen: Term<T, A>, vElse: Term<T, A>): Expr<T, A>
@@ -194,7 +194,7 @@ operators.$switch = (args, data) => {
 
 Eval.ignoreNull = (expr) => (expr[Type.kType]!.ignoreNull = true, expr)
 Eval.select = multary('select', (args, table) => args.map(arg => executeEval(table, arg)), Type.Array())
-Eval.query = (row, query) => ({ $expr: true, ...query }) as any
+Eval.query = (row, query, expr = true) => ({ $expr: expr, ...query }) as any
 
 // univeral
 Eval.if = multary('if', ([cond, vThen, vElse], data) => executeEval(data, cond) ? executeEval(data, vThen)

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -256,7 +256,7 @@ export namespace Model {
 export interface Model extends Model.Config {}
 
 export class Model<S = any> {
-  ctx?: Context
+  declare ctx?: Context
   fields: Field.Config<S> = {}
   migrations = new Map<Model.Migration, string[]>()
 

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -287,7 +287,7 @@ export class Selection<S = any> extends Executable<S, S[]> {
   }
 
   execute(): Promise<S[]>
-  execute<K extends FlatKeys<S> = any>(cursor?: Driver.Cursor<S, any, K>): Promise<FlatPick<S, K>[]>
+  execute<K extends FlatKeys<S> = any>(cursor?: Driver.Cursor<K, S>): Promise<FlatPick<S, K>[]>
   execute<T>(callback: Selection.Callback<S, T, true>): Promise<T>
   async execute(cursor?: any) {
     if (typeof cursor === 'function') {

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -287,7 +287,7 @@ export class Selection<S = any> extends Executable<S, S[]> {
   }
 
   execute(): Promise<S[]>
-  execute<K extends FlatKeys<S> = any>(cursor?: Driver.Cursor<K, S>): Promise<FlatPick<S, K>[]>
+  execute<K extends FlatKeys<S> = any>(cursor?: Driver.Cursor<K>): Promise<FlatPick<S, K>[]>
   execute<T>(callback: Selection.Callback<S, T, true>): Promise<T>
   async execute(cursor?: any) {
     if (typeof cursor === 'function') {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -128,9 +128,14 @@ export function flatten(source: object, prefix = '', ignore: (value: any) => boo
   return result
 }
 
-export function getCell(row: any, key: any): any {
-  if (key in row) return row[key]
-  return key.split('.').reduce((r, k) => r === undefined ? undefined : r[k], row)
+export function getCell(row: any, path: any): any {
+  if (path in row) return row[path]
+  if (path.includes('.')) {
+    const index = path.indexOf('.')
+    return getCell(row[path.slice(0, index)] ?? {}, path.slice(index + 1))
+  } else {
+    return row[path]
+  }
 }
 
 export function isEmpty(value: any) {

--- a/packages/sql-utils/src/index.ts
+++ b/packages/sql-utils/src/index.ts
@@ -391,7 +391,7 @@ export class Builder {
         const flattenQuery = isFlat(query[key]) ? { [key]: query[key] } : flatten(query[key], `${key}.`)
         for (const key in flattenQuery) {
           const model = this.state.tables![this.state.table!] ?? Object.values(this.state.tables!)[0]
-          const expr = Eval('', [Object.keys(this.state.tables!)[0], key], model.getType(key)!)
+          const expr = Eval('', [this.state.table ?? Object.keys(this.state.tables!)[0], key], model.getType(key)!)
           conditions.push(this.parseFieldQuery(this.parseEval(expr), flattenQuery[key]))
         }
       }

--- a/packages/tests/src/object.ts
+++ b/packages/tests/src/object.ts
@@ -226,6 +226,15 @@ namespace ObjectOperations {
         y: database.select('object').where(row => $.lt(row.meta.embed.b, 100)),
       }).execute(row => $.sum(1))).to.eventually.deep.equal(4)
     })
+
+    it('switch model in object query', async () => {
+      const table = await setup(database)
+      await expect(database.select('object', {
+        'meta.a': '666',
+      }).project({
+        t: 'meta',
+      }).execute()).to.eventually.have.deep.members([{ t: table[1].meta }])
+    })
   }
 }
 

--- a/packages/tests/src/relation.ts
+++ b/packages/tests/src/relation.ts
@@ -1175,10 +1175,22 @@ namespace RelationTests {
       await setup(database, 'user', [])
 
       await database.upsert('user', [
-        { id: 1, value: 1, successor: { id: 2 } },
-        { id: 2, value: 2, successor: { id: 1 } },
+        { id: 1, value: 1 },
+        { id: 2, value: 2 },
         { id: 3, value: 3 },
       ])
+      await database.set('user', 1, {
+        successor: {
+          $upsert: {
+            id: 2,
+          },
+        },
+        predecessor: {
+          $upsert: {
+            id: 2,
+          },
+        },
+      })
       await database.set('user', 3, {
         successor: {
           $create: {

--- a/packages/tests/src/relation.ts
+++ b/packages/tests/src/relation.ts
@@ -1397,11 +1397,11 @@ namespace RelationTests {
         posts: {
           $set: [
             {
-              where: r => $.query(r, { score: { $gt: 2 } }),
+              where: { score: { $gt: 2 } },
               update: r => ({ score: $.add(r.score, 10) }),
             },
             {
-              where: { score: 2 },
+              where: r => $.eq(r.score, 2),
               update: r => ({ score: $.add(r.score, 10) }),
             },
           ],

--- a/packages/tests/src/relation.ts
+++ b/packages/tests/src/relation.ts
@@ -709,11 +709,17 @@ namespace RelationTests {
             value: 4,
           },
         },
+        successor: {
+          $upsert: {
+            id: 6,
+            value: 6,
+          },
+        },
       })
       await expect(database.select('user', {}, { successor: true }).orderBy('id').execute()).to.eventually.have.shape([
         { id: 1, value: 1, successor: { id: 2, value: 2 } },
         { id: 2, value: 2, successor: null },
-        { id: 3, value: 3, successor: null },
+        { id: 3, value: 3, successor: { id: 6, value: 6 } },
         { id: 4, value: 4, successor: { id: 3, value: 3 } },
         { id: 6, value: 6 },
       ])
@@ -1274,15 +1280,19 @@ namespace RelationTests {
 
       await database.set('post', 1, {
         author: {
-          $create: {
+          $upsert: {
             id: 1,
             value: 0,
-            profile: {
-              $create: {
-                name: 'Apple',
-              },
-            },
           },
+        },
+      })
+      await database.set('post', 1, {
+        author: {
+          $set: _ => ({
+            profile: {
+              name: 'Apple',
+            },
+          }),
         },
       })
       await expect(database.select('user', {}, { posts: true, profile: true }).execute()).to.eventually.have.shape(

--- a/packages/tests/src/utils.ts
+++ b/packages/tests/src/utils.ts
@@ -1,10 +1,12 @@
+import { mapValues } from 'cosmokit'
 import { Database } from 'minato'
 
 export async function setup<S, K extends keyof S & string>(database: Database<S>, name: K, table: Partial<S[K]>[]) {
   await database.remove(name, {})
   const result: S[K][] = []
   for (const item of table) {
-    result.push(await database.create(name, item as any))
+    const data: any = mapValues(item, (v, k) => (v && database.tables[name].fields[k]?.relation) ? { $literal: v } : v)
+    result.push(await database.create(name, data))
   }
   return result
 }


### PR DESCRIPTION
feat: adjust default behavior for relation shorthand
feat: add $literal in Create to ignore relations
fix: field collision in groupBy when query multiple relations
fix: $upsert in toOne not modify self table
fix: enhance all query syntax in relation modifier
chore: revert type param order of Driver.Cursor
refa: set self table in relation update