### PR TITLE
feat(minato): impl `$.get`

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -203,11 +203,11 @@ export class Database<S = {}, N = {}, C extends Context = Context> extends Servi
   private _parseField(field: any, transformers: Driver.Transformer[] = [], setInitial?: (value) => void, setField?: (value) => void): Type {
     if (field === 'object') {
       setInitial?.({})
-      setField?.({ type: 'json', initial: {} })
+      setField?.({ initial: {}, deftype: 'json', type: Type.Object() })
       return Type.Object()
     } else if (field === 'array') {
       setInitial?.([])
-      setField?.({ type: 'json', initial: [] })
+      setField?.({ initial: [], deftype: 'json', type: Type.Array() })
       return Type.Array()
     } else if (typeof field === 'string' && this.types[field]) {
       transformers.push({

--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -149,6 +149,9 @@ export namespace Eval {
     object<T extends any>(row: Row.Cell<T>): Expr<T, false>
     object<T extends any>(row: Row<T>): Expr<T, false>
     array<T>(value: Expr<T, false>): Expr<T[], true>
+
+    get<T extends object, K extends keyof T, A extends boolean>(x: Term<T, A>, key: K): Expr<T[K], A>
+    get<T extends any, A extends boolean>(x: Array<T, A>, index: Term<number, A>): Expr<T, A>
   }
 }
 
@@ -326,6 +329,8 @@ Eval.object = (fields: any) => {
 Eval.array = unary('array', (expr, table) => Array.isArray(table)
   ? table.map(data => executeAggr(expr, data)).filter(x => !expr[Type.kType]?.ignoreNull || !isEmpty(x))
   : Array.from(executeEval(table, expr)).filter(x => !expr[Type.kType]?.ignoreNull || !isEmpty(x)), (expr) => Type.Array(Type.fromTerm(expr)))
+
+Eval.get = multary('get', ([x, key], data) => executeEval(data, x)?.[executeEval(data, key)], (x, key) => Type.getInner(Type.fromTerm(x), key) ?? Type.Any)
 
 Eval.exec = unary('exec', (expr, data) => (expr.driver as any).executeSelection(expr, data), (expr) => Type.fromTerm(expr.args[0]))
 

--- a/packages/memory/tests/index.spec.ts
+++ b/packages/memory/tests/index.spec.ts
@@ -19,12 +19,18 @@ describe('@minatojs/driver-memory', () => {
     update: {
       index: false,
     },
+    json: {
+      query: {
+        nullableComparator: false,
+      },
+    },
     model: {
       fields: {
         cast: false,
         typeModel: false,
       },
       object: {
+        nullableComparator: false,
         typeModel: false,
       },
     },

--- a/packages/mongo/src/builder.ts
+++ b/packages/mongo/src/builder.ts
@@ -262,6 +262,10 @@ export class Builder {
         }
       },
 
+      $get: ([x, key], group) => typeof key === 'string'
+        ? (key as string).split('.').reduce((res, k) => ({ $getField: { input: res, field: k } }), this.eval(x, group))
+        : { $arrayElemAt: [this.eval(x, group), this.eval(key, group)] },
+
       $exec: (arg, group) => {
         const sel = arg as Selection
         const transformer = this.createSubquery(sel)

--- a/packages/postgres/src/builder.ts
+++ b/packages/postgres/src/builder.ts
@@ -94,6 +94,14 @@ export class PostgresBuilder extends Builder {
         else return `(${args.map(arg => this.parseEval(arg, 'bigint')).join(' # ')})`
       },
 
+      $get: ([x, key]) => {
+        const type = Type.fromTerm(this.state.expr, Type.Any)
+        const res = typeof key === 'string'
+          ? this.asEncoded(`jsonb_extract_path(${this.parseEval(x, false)}, ${(key as string).split('.').map(this.escapeKey).join(',')})`, true)
+          : this.asEncoded(`(${this.parseEval(x, false)})->(${this.parseEval(key, 'integer')})`, true)
+        return type.type === 'expr' ? res : `(${res})::${this.transformType(type)}`
+      },
+
       $number: (arg) => {
         const value = this.parseEval(arg)
         const type = Type.fromTerm(arg)

--- a/packages/sql-utils/src/index.ts
+++ b/packages/sql-utils/src/index.ts
@@ -394,31 +394,13 @@ export class Builder {
         const flattenQuery = isFlat(query[key]) ? { [key]: query[key] } : flatten(query[key], `${key}.`)
         for (const key in flattenQuery) {
           const model = this.state.tables![this.state.table!] ?? Object.values(this.state.tables!)[0]
-          const expr = this.transformQueryPath(this.state.table ?? Object.keys(this.state.tables!)[0], model, key)
+          const expr = Eval('', [this.state.table ?? Object.keys(this.state.tables!)[0], key], model.getType(key)!)
           conditions.push(this.parseFieldQuery(this.parseEval(expr), flattenQuery[key]))
         }
       }
     }
 
     return this.logicalAnd(conditions)
-  }
-
-  protected transformQueryPath(ref: string, model: Model, key: string) {
-    let intermediate = false, path = ''
-    const segments = key.split('.')
-    let expr: Eval.Expr | undefined
-    for (const segment of segments) {
-      if (Number.isInteger(+segment)) {
-        expr = Eval.get(expr, +segment)
-        intermediate = true
-      } else if (intermediate) {
-        expr = Eval.get(expr, segment)
-      } else {
-        path = path ? `${path}.${segment}` : segment
-        expr = Eval('', [ref, path], model.getType(path)!)
-      }
-    }
-    return expr
   }
 
   protected parseEvalExpr(expr: any) {

--- a/packages/sqlite/src/builder.ts
+++ b/packages/sqlite/src/builder.ts
@@ -39,6 +39,9 @@ export class SQLiteBuilder extends Builder {
       if (Field.boolean.includes(type.type)) return args.map(arg => this.parseEval(arg)).reduce((prev, curr) => `(${prev} != ${curr})`)
       else return args.map(arg => this.parseEval(arg)).reduce((prev, curr) => binaryXor(prev, curr))
     }
+    this.evalOperators.$get = ([x, key]) => typeof key === 'string'
+      ? this.asEncoded(`(${this.parseEval(x, false)} -> '$.${key}')`, true)
+      : this.asEncoded(`(${this.parseEval(x, false)} -> ('$[' || ${this.parseEval(key)} || ']'))`, true)
 
     this.transformers['bigint'] = {
       encode: value => `cast(${value} as text)`,

--- a/packages/tests/src/json.ts
+++ b/packages/tests/src/json.ts
@@ -154,20 +154,6 @@ namespace JsonTests {
         .to.eventually.deep.equal([
           { id: 1, nums: [4, 5, 6] },
         ])
-
-      await expect(database.get('baz', { 'nums.0': 4 }))
-        .to.eventually.deep.equal([
-          { id: 1, nums: [4, 5, 6] },
-        ])
-
-      await expect(database.get('baz', {
-        nums: {
-          0: 4,
-        },
-      }))
-        .to.eventually.deep.equal([
-          { id: 1, nums: [4, 5, 6] },
-        ])
     })
 
     nullableComparator && it('$get array with expressions', async () => {

--- a/packages/tests/src/json.ts
+++ b/packages/tests/src/json.ts
@@ -56,7 +56,10 @@ function JsonTests(database: Database<Tables>) {
 
   database.extend('baz', {
     id: 'unsigned',
-    nums: { type: 'json', initial: [] },
+    nums: {
+      type: 'array',
+      inner: 'unsigned',
+    }
   })
 
   before(async () => {
@@ -81,7 +84,13 @@ function JsonTests(database: Database<Tables>) {
 }
 
 namespace JsonTests {
-  export function query(database: Database<Tables>) {
+  export interface RelationOptions {
+    nullableComparator?: boolean
+  }
+
+  export function query(database: Database<Tables>, options: RelationOptions = {}) {
+    const { nullableComparator = true } = options
+
     it('$size', async () => {
       await expect(database.get('baz', {
         nums: { $size: 3 },
@@ -133,6 +142,51 @@ namespace JsonTests {
     it('execute nested selection', async () => {
       await expect(database.eval('bar', row => $.max($.add(1, row.value)))).to.eventually.deep.equal(2)
       await expect(database.eval('bar', row => $.max($.add(1, row.obj.x)))).to.eventually.deep.equal(4)
+    })
+
+    it('$get array', async () => {
+      await expect(database.get('baz', row => $.eq($.get(row.nums, 0), 4)))
+        .to.eventually.deep.equal([
+          { id: 1, nums: [4, 5, 6] },
+        ])
+
+      await expect(database.get('baz', row => $.eq(row.nums[0], 4)))
+        .to.eventually.deep.equal([
+          { id: 1, nums: [4, 5, 6] },
+        ])
+
+      await expect(database.get('baz', { 'nums.0': 4 }))
+        .to.eventually.deep.equal([
+          { id: 1, nums: [4, 5, 6] },
+        ])
+
+      await expect(database.get('baz', {
+        nums: {
+          0: 4,
+        },
+      }))
+        .to.eventually.deep.equal([
+          { id: 1, nums: [4, 5, 6] },
+        ])
+    })
+
+    nullableComparator && it('$get array with expressions', async () => {
+      await expect(database.get('baz', row => $.eq($.get(row.nums, $.add(row.id, -1)), 4)))
+        .to.eventually.deep.equal([
+          { id: 1, nums: [4, 5, 6] },
+        ])
+    })
+
+    it('$get object', async () => {
+      await expect(database.get('bar', row => $.eq(row.obj.o.a, 2)))
+        .to.eventually.have.shape([
+          { value: 1 },
+        ])
+
+      await expect(database.get('bar', row => $.eq($.get(row.obj.o, 'a'), 2)))
+        .to.eventually.have.shape([
+          { value: 1 },
+        ])
     })
   }
 

--- a/packages/tests/src/model.ts
+++ b/packages/tests/src/model.ts
@@ -308,6 +308,7 @@ namespace ModelOperations {
     cast?: boolean
     typeModel?: boolean
     aggregateNull?: boolean
+    nullableComparator?: boolean
   }
 
   export const fields = function Fields(database: Database<Tables, Types>, options: ModelOptions = {}) {
@@ -513,7 +514,7 @@ namespace ModelOperations {
   }
 
   export const object = function ObjectFields(database: Database<Tables, Types>, options: ModelOptions = {}) {
-    const { aggregateNull = true, typeModel = true } = options
+    const { aggregateNull = true, nullableComparator = true, typeModel = true } = options
 
     it('basic', async () => {
       const table = await setup(database, 'dobjects', dobjectTable)
@@ -634,6 +635,12 @@ namespace ModelOperations {
       await expect(database.get('dobjects', row => $.eq($.or(row.foo!.nested!.int64!, 4n), 127n))).to.eventually.have.length(1)
       await expect(database.get('dobjects', row => $.eq($.xor(row.foo!.nested!.int64!, 2n), 121n))).to.eventually.have.length(1)
       await expect(database.eval('dobjects', row => $.max($.or(row.foo!.nested!.int64!, 9223372036854775701n)))).eventually.to.deep.equal(9223372036854775807n)
+    })
+
+    nullableComparator && it('nested $get', async () => {
+      await setup(database, 'dobjects', dobjectTable)
+      await expect(database.get('dobjects', row => $.eq(row.baz[0].nested.id, 1))).to.eventually.have.length(2)
+      await expect(database.get('dobjects', { 'baz.0.nested.id': 1 })).to.eventually.have.length(2)
     })
   }
 }

--- a/packages/tests/src/model.ts
+++ b/packages/tests/src/model.ts
@@ -641,6 +641,7 @@ namespace ModelOperations {
       await setup(database, 'dobjects', dobjectTable)
       await expect(database.get('dobjects', row => $.eq(row.baz[0].nested.id, 1))).to.eventually.have.length(2)
       await expect(database.get('dobjects', { 'baz.0.nested.id': 1 })).to.eventually.have.length(2)
+      await expect(database.get('dobjects', row => $.eq(row.baz[0].nested.array[0], 1))).to.eventually.have.length(2)
     })
   }
 }

--- a/packages/tests/src/model.ts
+++ b/packages/tests/src/model.ts
@@ -640,7 +640,6 @@ namespace ModelOperations {
     nullableComparator && it('nested $get', async () => {
       await setup(database, 'dobjects', dobjectTable)
       await expect(database.get('dobjects', row => $.eq(row.baz[0].nested.id, 1))).to.eventually.have.length(2)
-      await expect(database.get('dobjects', { 'baz.0.nested.id': 1 })).to.eventually.have.length(2)
       await expect(database.get('dobjects', row => $.eq(row.baz[0].nested.array[0], 1))).to.eventually.have.length(2)
     })
   }


### PR DESCRIPTION
## Motivation
`object[key]` / `array[index]`

## Eval
```typescript
// Field of object only support string constant
get<T extends object, K extends keyof T, A extends boolean>(x: Term<T, A>, key: K): Expr<T[K], A>
// Index of array can be of any Expr<number>
get<T extends any, A extends boolean>(x: Array<T, A>, index: Term<number, A>): Expr<T, A>
```

## Query
**Reverted***

## Modifier

Not yet supported