### PR TITLE
feat(minato): support filtering relation fields

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -37,7 +37,7 @@ export namespace Relation {
   }
 
   export type Include<T, S> = boolean | {
-    [P in keyof T]?: T[P] extends MaybeArray<infer U> | undefined ? U extends S ? Include<U, S> : never : never
+    [P in keyof T]?: T[P] extends MaybeArray<infer U> | undefined ? U extends S ? Include<U, S> : Query.Expr<Flatten<U>> : never
   }
 
   export type SetExpr<S extends object = any> = ((row: Row<S>) => Update<S>) | {


### PR DESCRIPTION
```typescript
database.get('user', {
        posts: {
          $some: {
            id2: 1,
          },
        },
      }, {
        include: {
          posts: {
            id2: 1,
          },
        },
      }
```