### PR TITLE
fix(mongo): mis-order of eval and dump, $.literal

### DIFF
--- a/packages/core/src/eval.ts
+++ b/packages/core/src/eval.ts
@@ -277,10 +277,7 @@ Eval.xor = multary('xor', (args, data) => {
 }, (...args) => Type.fromTerms(args, Type.Boolean))
 
 // typecast
-Eval.literal = multary('literal', ([value, type]) => {
-  if (type) throw new TypeError('literal cast is not supported')
-  else return value
-}, (value, type) => type ? Type.fromField(type) : Type.fromTerm(value))
+Eval.literal = multary('literal', ([value, type]) => value, (value, type) => type ? Type.fromField(type) : Type.fromTerm(value))
 Eval.number = unary('number', (arg, data) => {
   const value = executeEval(data, arg)
   return value instanceof Date ? Math.floor(value.valueOf() / 1000) : Number(value)

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -1,6 +1,6 @@
 import { clone, deepEqual, defineProperty, filterKeys, isNullable, makeArray, mapValues, MaybeArray } from 'cosmokit'
 import { Context } from 'cordis'
-import { Eval, Update } from './eval.ts'
+import { Eval, isEvalExpr, Update } from './eval.ts'
 import { DeepPartial, FlatKeys, Flatten, isFlat, Keys, Row, unravel } from './utils.ts'
 import { Type } from './type.ts'
 import { Driver } from './driver.ts'
@@ -349,7 +349,7 @@ export class Model<S = any> {
     const result = {}
     for (const key in obj) {
       const type = Type.getInner(model, key)
-      if (!type || isNullable(obj[key])) {
+      if (!type || isNullable(obj[key]) || isEvalExpr(obj[key])) {
         result[key] = obj[key]
       } else if (type.type !== 'json') {
         result[key] = this.resolveValue(type, obj[key])

--- a/packages/core/src/type.ts
+++ b/packages/core/src/type.ts
@@ -58,7 +58,9 @@ export namespace Type {
   // FIXME: Type | Field<T> | Field.Type<T> | Keys<N, T> | Field.NewType<T>
   export function fromField<T, N>(field: any): Type<T, N> {
     if (isType(field)) return field
-    if (typeof field === 'string') return defineProperty({ type: field }, kType, true) as never
+    else if (field === 'array') return Array() as never
+    else if (field === 'object') return Object() as never
+    else if (typeof field === 'string') return defineProperty({ type: field }, kType, true) as never
     else if (field.type) return field.type
     else if (field.expr?.[kType]) return field.expr[kType]
     throw new TypeError(`invalid field: ${field}`)

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -354,8 +354,7 @@ export class MongoDriver extends Driver<MongoDriver.Config> {
       const coll = this.db.collection(table)
 
       const transformer = new Builder(this, Object.keys(sel.tables), this.getVirtualKey(table), '$' + tempKey + '.')
-      const $set = this.builder.formatUpdateAggr(model.getType(), mapValues(this.builder.dump(update, model),
-        (value: any) => typeof value === 'string' && value.startsWith('$') ? { $literal: value } : transformer.eval(value)))
+      const $set = mapValues(update, (item: any, key) => transformer.toUpdateExpr(item, model.getType(key)))
       const $unset = Object.entries($set)
         .filter(([_, value]) => typeof value === 'object')
         .map(([key, _]) => key)
@@ -472,8 +471,7 @@ export class MongoDriver extends Driver<MongoDriver.Config> {
       for (const update of data) {
         const query = this.transformQuery(sel, pick(update, keys), table)!
         const transformer = new Builder(this, Object.keys(sel.tables), this.getVirtualKey(table), '$' + tempKey + '.')
-        const $set = this.builder.formatUpdateAggr(model.getType(), mapValues(this.builder.dump(update, model),
-          (value: any) => typeof value === 'string' && value.startsWith('$') ? { $literal: value } : transformer.eval(value)))
+        const $set = mapValues(update, (item: any, key) => transformer.toUpdateExpr(item, model.getType(key)))
         const $unset = Object.entries($set)
           .filter(([_, value]) => typeof value === 'object')
           .map(([key, _]) => key)


### PR DESCRIPTION
support auto escaping for $-prefixed-string in nested typed object
fix $.literal when using with json output type